### PR TITLE
fix source bug. it occured at N:1 source mapping.

### DIFF
--- a/lib/multi-stage-sourcemap.js
+++ b/lib/multi-stage-sourcemap.js
@@ -22,7 +22,7 @@ function transfer(parameters) {
         var originalPosition = toSMC.originalPositionFor(fromOriginalPosition);
         if (originalPosition.source !== null) {
             resultMap.addMapping({
-                source: path.basename(toSMC.file),
+                source: originalPosition.source,
                 name : originalPosition.name,
                 generated: generatedPosition,
                 original: originalPosition

--- a/test/multi-stage-sourcemap-test.js
+++ b/test/multi-stage-sourcemap-test.js
@@ -46,7 +46,7 @@ describe("multi-stage-sourcemap", function () {
             line: 4,
             column: 4
         });
-        assert(originalPosition.source === 'original.js');
+        assert(originalPosition.source === '/path/to/root/original.js');
         assert(originalPosition.line === 1);
         assert(originalPosition.column === 0);
     });


### PR DESCRIPTION
@azu 
https://github.com/mozilla/source-map#sourcemapgeneratorprototypeaddmappingmapping
source are mapping for source index.

https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit#heading=h.mofvlxcwqzej
Revision 3 Format > Proposed Format > Line 8 > The fields in each segment are:

> If present, an zero-based index into the “sources” list. This field is a base 64 VLQ relative to the previous occurrence of this field, unless this is the first occurrence of this field, in which case the whole value is represented.

toSMC.file is not root source file. (e.g. foo.coffee -> foo.js -> foo.min.js. toSMC.file === foo.js, not foo.coffee)

https://gist.github.com/twada/103d34a3237cecd463a6
