### PR TITLE
Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Return the re-mapped `rawSourceMap` string.
 
 The only argument is an object with the following properties:
 
-- `fromSourceMap` : String - JSON.stringify(rawSourceMap)
-- `toSourceMap` : String - JSON.stringify(rawSourceMap)
+- `fromSourceMap` : Object - rawSourceMap or String - JSON.stringify(rawSourceMap)
+- `toSourceMap` : Object - rawSourceMap or String - JSON.stringify(rawSourceMap)
 
 `rawSourceMap` is like below object.
 


### PR DESCRIPTION
sourcemap can take not just a string but also a raw source map object as a parameter. It converts passed string to object internally anyway, so if the consumer of the multi-stage-sourcemap already has a raw source map object, converting it to string (and then back to object by sourcemap) results in an unnecessary performance penalty
